### PR TITLE
Reduce memory consumption from 750MB to 60MB by using CSV not JSON. (Also lots of other changes.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,27 @@ pytzwhere is a Python library to lookup the timezone for a given lat/lng entirel
 
 It is a port from https://github.com/mattbornski/tzwhere with a few improvements.
 
-Instructions and usage information can be seen by running:
-./tzwhere.py --help
+If used as a library, basic usage is as follows:
+
+    >>> import tzwhere
+    >>> tz = tzwhere.tzwhere()
+    Reading json input file: tz_world_compact.json
+    >>> print tz.tzNameAt(35.29, -89.66)
+    America/Chicago
+
+By default (and as shown above), the `tzwhere` class (at the heart of this library) initialises itself from a JSON file.  Note that this is very very memory hungry (about 750MB, though the file is much smaller).  You can save a lot of memory (hundred of megabytes) at the cost of another second or so initialisation time, by telling `tzwhere` to read its data in (one line at a time) from a CSV file instead:
+
+    >>> tz = tzwhere.tzwhere(input_kind='csv')
+    Reading from CSV input file: tz_world.csv
+    >>> print tz.tzNameAt(35.29, -89.66)
+    America/Chicago
+
+The module can also be run as a script, which offers some other possibilities including producing the CSV file mentioned above.  Instructions and usage information can be seen by running:
+
+    tzwhere.py --help
+
+Dependencies (both optional):
+
+  * `docopt` - if you want to use `tzwhere.py` as a script (e.g. as shown above).
+
+  * `numpy` - if you want to save about 200MB of RAM.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
     version='1.0',
     packages=['tzwhere'],
     package_data={
-        'tzwhere': ['tz_world.json', 'tz_world_compact.json', 'tz_world.pickle']
+        'tzwhere': ['tz_world.json', 'tz_world_compact.json',
+                    'tz_world.pickle', 'tz_world.csv']
         },
     include_package_data=True,
     license='MIT License',

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -40,6 +40,8 @@ class tzwhere(object):
             pgen = tzwhere._feature_collection_polygons(featureCollection)
         elif input_kind == 'csv':
             pgen = tzwhere._read_polygons_from_csv(path)
+        else:
+            raise ValueError(input_kind)
 
         # Turn that into an internal mapping.
         self._construct_polygon_map(pgen)

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -19,6 +19,13 @@ import math
 import os
 import pickle
 
+# We can save about 222MB of RAM by turning our polygon lists into
+# numpy arrays rather than tuples, if numpy is installed.
+try:
+    import numpy
+    WRAP = numpy.array
+except ImportError:
+    WRAP = tuple
 
 class tzwhere(object):
 
@@ -56,12 +63,13 @@ class tzwhere(object):
             if tzname not in self.timezoneNamesToPolygons:
                 self.timezoneNamesToPolygons[tzname] = []
             self.timezoneNamesToPolygons[tzname].append(
-                tuple(tzwhere._raw_poly_to_poly(raw_poly)))
+                WRAP(tzwhere._raw_poly_to_poly(raw_poly)))
 
-        # Convert things to tuples to save memory
+        # Convert polygon lists to numpy arrays or (failing that)
+        # tuples to save memory.
         for tzname in self.timezoneNamesToPolygons.keys():
             self.timezoneNamesToPolygons[tzname] = \
-                tuple(self.timezoneNamesToPolygons[tzname])
+                WRAP(self.timezoneNamesToPolygons[tzname])
 
     def _construct_shortcuts(self):
 

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -125,7 +125,7 @@ class tzwhere(object):
 
         p1x, p1y = poly[0][1], poly[0][0]
         for i in range(n + 1):
-            p2x, p2y = poly[i % n][0], poly[i % n][1]
+            p2x, p2y = poly[i % n][1], poly[i % n][0]
             if y > min(p1y, p2y):
                 if y <= max(p1y, p2y):
                     if x <= max(p1x, p2x):

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -1,4 +1,22 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
+"""tzwhere.py - time zone computation from latitude/longitude.
+
+Ordinarily this is loaded as a module and instances of the tzwhere
+class are instantiated and queried directly, but the module can be run
+as a script too, in which case it operates as follows:
+
+Usage:
+  tzwhere.py [options]
+
+Options:
+  --json_file=<file>    Path to the json input file [default: tz_world_compact.json].
+  --pickle_file=<file>  Path to the pickle input file [default: tz_world.pickle].
+  --read_pickle         Read pickle data instead of json [default: False].
+  --write_pickle        Whether to output a pickle file [default: False].
+  -h, --help            Show this help.
+
+"""
 
 try:
     import json
@@ -151,30 +169,18 @@ class tzwhere(object):
                         if self._point_inside_polygon(longitude, latitude, poly):
                             return tzname
 
-if __name__ == "__main__":
-    import argparse
-    parser = argparse.ArgumentParser(description='''
-    Convert lat/lng to timezones.
-    Specify --read_pickle to initialize from a pickle file instead of
-    the json file.
-''')
-    parser.add_argument('--json_file', default='tz_world_compact.json',
-                    help='path to the json input file')
-    parser.add_argument('--pickle_file', default='tz_world.pickle',
-                    help='path to the pickle input file')
-    parser.add_argument('--read_pickle', action='store_true',
-                    help='read pickle data instead of json')
-    parser.add_argument('--write_pickle', action='store_true',
-                    help='whether to output a pickle file')
-    args = parser.parse_args()
 
-    if args.read_pickle:
-        filename = args.pickle_file
+def main():
+    import docopt
+
+    args = docopt.docopt(__doc__)
+    if args['--read_pickle']:
+        filename = args['--pickle_file']
     else:
-        filename = args.json_file
+        filename = args['--json_file']
 
     start = datetime.datetime.now()
-    w = tzwhere(filename, args.read_pickle, args.write_pickle)
+    w = tzwhere(filename, args['--read_pickle'], args['--write_pickle'])
     end = datetime.datetime.now()
     print 'Initialized in: ',
     print end - start
@@ -183,3 +189,7 @@ if __name__ == "__main__":
     print w.tzNameAt(float(61.17), float(-150.02))  # Anchorage, AK
     print w.tzNameAt(float(44.12), float(-123.22))  # Eugene, OR
     print w.tzNameAt(float(42.652647), float(-73.756371))  # Albany, NY
+
+
+if __name__ == "__main__":
+    main()

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -16,6 +16,8 @@ class tzwhere(object):
     # By default, use the data file in our package directory
     DEFAULT_FILENAME = os.path.join(os.path.dirname(__file__),
         'tz_world_compact.json')
+    PICKLE_FILENAME = os.path.join(os.path.dirname(__file__),
+        'tz_world.pickle')
 
     def __init__(self, filename=DEFAULT_FILENAME, read_pickle=False,
             write_pickle=False):
@@ -32,11 +34,10 @@ class tzwhere(object):
         input_file.close()
 
         if write_pickle:
-            print 'Writing pickle output file: %s' % PICKLE_FILENAME
-            f = open(PICKLE_FILENAME, 'w')
+            print 'Writing pickle output file: %s' % self.PICKLE_FILENAME
+            f = open(self.PICKLE_FILENAME, 'w')
             pickle.dump(featureCollection, f, pickle.HIGHEST_PROTOCOL)
             f.close()
-
 
         self.timezoneNamesToPolygons = {}
         for feature in featureCollection['features']:
@@ -48,9 +49,11 @@ class tzwhere(object):
                     self.timezoneNamesToPolygons[tzname] = []
 
                 for raw_poly in polys:
-                    #WPS84 coordinates are [long, lat], while many conventions are [lat, long]
-                    #Our data is in WPS84.  Convert to an explicit format which geolib likes.
-                    assert len(raw_poly)%2 == 0
+                    # WPS84 coordinates are [long, lat], while many
+                    # conventions are [lat, long] Our data is in
+                    # WPS84.  Convert to an explicit format which
+                    # geolib likes.
+                    assert len(raw_poly) % 2 == 0
                     poly = []
                     while raw_poly:
                         lat = raw_poly.pop()
@@ -58,16 +61,20 @@ class tzwhere(object):
                         poly.append({'lat': lat, 'lng': lng})
                     self.timezoneNamesToPolygons[tzname].append(tuple(poly))
 
-        self.timezoneLongitudeShortcuts = {};
-        self.timezoneLatitudeShortcuts = {};
+        self.timezoneLongitudeShortcuts = {}
+        self.timezoneLatitudeShortcuts = {}
         for tzname in self.timezoneNamesToPolygons:
             for polyIndex, poly in enumerate(self.timezoneNamesToPolygons[tzname]):
                 lats = [x['lat'] for x in poly]
                 lngs = [x['lng'] for x in poly]
-                minLng = math.floor(min(lngs) / self.SHORTCUT_DEGREES_LONGITUDE) * self.SHORTCUT_DEGREES_LONGITUDE;
-                maxLng = math.floor(max(lngs) / self.SHORTCUT_DEGREES_LONGITUDE) * self.SHORTCUT_DEGREES_LONGITUDE;
-                minLat = math.floor(min(lats) / self.SHORTCUT_DEGREES_LATITUDE) * self.SHORTCUT_DEGREES_LATITUDE;
-                maxLat = math.floor(max(lats) / self.SHORTCUT_DEGREES_LATITUDE) * self.SHORTCUT_DEGREES_LATITUDE;
+                minLng = (math.floor(min(lngs) / self.SHORTCUT_DEGREES_LONGITUDE)
+                          * self.SHORTCUT_DEGREES_LONGITUDE)
+                maxLng = (math.floor(max(lngs) / self.SHORTCUT_DEGREES_LONGITUDE)
+                          * self.SHORTCUT_DEGREES_LONGITUDE)
+                minLat = (math.floor(min(lats) / self.SHORTCUT_DEGREES_LATITUDE)
+                          * self.SHORTCUT_DEGREES_LATITUDE)
+                maxLat = (math.floor(max(lats) / self.SHORTCUT_DEGREES_LATITUDE)
+                          * self.SHORTCUT_DEGREES_LATITUDE)
                 degree = minLng
                 while degree <= maxLng:
                     if degree not in self.timezoneLongitudeShortcuts:
@@ -90,55 +97,66 @@ class tzwhere(object):
                     self.timezoneLatitudeShortcuts[degree][tzname].append(polyIndex)
                     degree = degree + self.SHORTCUT_DEGREES_LATITUDE
 
-        #convert things to tuples to save memory
+        # Convert things to tuples to save memory
         for tzname in self.timezoneNamesToPolygons.keys():
-            self.timezoneNamesToPolygons[tzname] = tuple(self.timezoneNamesToPolygons[tzname])
+            self.timezoneNamesToPolygons[tzname] = \
+                tuple(self.timezoneNamesToPolygons[tzname])
         for degree in self.timezoneLatitudeShortcuts:
             for tzname in self.timezoneLatitudeShortcuts[degree].keys():
-                self.timezoneLatitudeShortcuts[degree][tzname] = tuple(self.timezoneLatitudeShortcuts[degree][tzname])
+                self.timezoneLatitudeShortcuts[degree][tzname] = \
+                    tuple(self.timezoneLatitudeShortcuts[degree][tzname])
         for degree in self.timezoneLongitudeShortcuts.keys():
             for tzname in self.timezoneLongitudeShortcuts[degree].keys():
-                self.timezoneLongitudeShortcuts[degree][tzname] = tuple(self.timezoneLongitudeShortcuts[degree][tzname])
+                self.timezoneLongitudeShortcuts[degree][tzname] = \
+                    tuple(self.timezoneLongitudeShortcuts[degree][tzname])
 
     def _point_inside_polygon(self, x, y, poly):
         n = len(poly)
-        inside =False
+        inside = False
 
         p1x, p1y = poly[0]['lng'], poly[0]['lat']
-        for i in range(n+1):
-            p2x,p2y = poly[i % n]['lng'], poly[i % n]['lat']
-            if y > min(p1y,p2y):
-                if y <= max(p1y,p2y):
-                    if x <= max(p1x,p2x):
+        for i in range(n + 1):
+            p2x, p2y = poly[i % n]['lng'], poly[i % n]['lat']
+            if y > min(p1y, p2y):
+                if y <= max(p1y, p2y):
+                    if x <= max(p1x, p2x):
                         if p1y != p2y:
-                            xinters = (y-p1y)*(p2x-p1x)/(p2y-p1y)+p1x
+                            xinters = (y - p1y) * (p2x - p1x) / (p2y - p1y) + p1x
                         if p1x == p2x or x <= xinters:
                             inside = not inside
-            p1x,p1y = p2x,p2y
+            p1x, p1y = p2x, p2y
 
         return inside
 
     def tzNameAt(self, latitude, longitude):
-        latTzOptions = self.timezoneLatitudeShortcuts[math.floor(latitude / self.SHORTCUT_DEGREES_LATITUDE) * self.SHORTCUT_DEGREES_LATITUDE]
-        latSet = set(latTzOptions.keys());
-        lngTzOptions = self.timezoneLongitudeShortcuts[math.floor(longitude / self.SHORTCUT_DEGREES_LONGITUDE) * self.SHORTCUT_DEGREES_LONGITUDE]
+        latTzOptions = self.timezoneLatitudeShortcuts[
+            (math.floor(latitude / self.SHORTCUT_DEGREES_LATITUDE)
+             * self.SHORTCUT_DEGREES_LATITUDE)
+        ]
+        latSet = set(latTzOptions.keys())
+        lngTzOptions = self.timezoneLongitudeShortcuts[
+            (math.floor(longitude / self.SHORTCUT_DEGREES_LONGITUDE)
+             * self.SHORTCUT_DEGREES_LONGITUDE)
+        ]
         lngSet = set(lngTzOptions.keys())
-        possibleTimezones = lngSet.intersection(latSet);
+        possibleTimezones = lngSet.intersection(latSet)
         if possibleTimezones:
             if False and len(possibleTimezones) == 1:
                 return possibleTimezones.pop()
             else:
                 for tzname in possibleTimezones:
-                    polyIndices = set(latTzOptions[tzname]).intersection(set(lngTzOptions[tzname]));
+                    polyIndices = set(latTzOptions[tzname]).intersection(set(lngTzOptions[tzname]))
                     for polyIndex in polyIndices:
-                        poly = self.timezoneNamesToPolygons[tzname][polyIndex];
+                        poly = self.timezoneNamesToPolygons[tzname][polyIndex]
                         if self._point_inside_polygon(longitude, latitude, poly):
                             return tzname
 
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='''
-    Convert lat/lng to timezones. Specify --read_pickle to initialize from a pickle file instead of the json file.
+    Convert lat/lng to timezones.
+    Specify --read_pickle to initialize from a pickle file instead of
+    the json file.
 ''')
     parser.add_argument('--json_file', default='tz_world_compact.json',
                     help='path to the json input file')
@@ -159,9 +177,9 @@ if __name__ == "__main__":
     w = tzwhere(filename, args.read_pickle, args.write_pickle)
     end = datetime.datetime.now()
     print 'Initialized in: ',
-    print end-start
-    print w.tzNameAt(float(35.295953), float(-89.662186)) #Arlington, TN
-    print w.tzNameAt(float(33.58), float(-85.85)) #Memphis, TN
-    print w.tzNameAt(float(61.17), float(-150.02)) #Anchorage, AK
-    print w.tzNameAt(float(44.12), float(-123.22)) #Eugene, OR
-    print w.tzNameAt(float(42.652647), float(-73.756371)) #Albany, NY
+    print end - start
+    print w.tzNameAt(float(35.295953), float(-89.662186))  # Arlington, TN
+    print w.tzNameAt(float(33.58), float(-85.85))  # Memphis, TN
+    print w.tzNameAt(float(61.17), float(-150.02))  # Anchorage, AK
+    print w.tzNameAt(float(44.12), float(-123.22))  # Eugene, OR
+    print w.tzNameAt(float(42.652647), float(-73.756371))  # Albany, NY

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -69,8 +69,8 @@ class tzwhere(object):
         self.timezoneLatitudeShortcuts = {}
         for tzname in self.timezoneNamesToPolygons:
             for polyIndex, poly in enumerate(self.timezoneNamesToPolygons[tzname]):
-                lats = [x['lat'] for x in poly]
-                lngs = [x['lng'] for x in poly]
+                lats = [x[0] for x in poly]
+                lngs = [x[1] for x in poly]
                 minLng = (math.floor(min(lngs) / self.SHORTCUT_DEGREES_LONGITUDE)
                           * self.SHORTCUT_DEGREES_LONGITUDE)
                 maxLng = (math.floor(max(lngs) / self.SHORTCUT_DEGREES_LONGITUDE)
@@ -115,9 +115,9 @@ class tzwhere(object):
         n = len(poly)
         inside = False
 
-        p1x, p1y = poly[0]['lng'], poly[0]['lat']
+        p1x, p1y = poly[0][1], poly[0][0]
         for i in range(n + 1):
-            p2x, p2y = poly[i % n]['lng'], poly[i % n]['lat']
+            p2x, p2y = poly[i % n][0], poly[i % n][1]
             if y > min(p1y, p2y):
                 if y <= max(p1y, p2y):
                     if x <= max(p1x, p2x):
@@ -228,7 +228,7 @@ class tzwhere(object):
         while raw_poly:
             lat = raw_poly.pop()
             lng = raw_poly.pop()
-            poly.append({'lat': lat, 'lng': lng})
+            poly.append((lat, lng))
         return poly
 
 

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -27,6 +27,7 @@ try:
 except ImportError:
     WRAP = tuple
 
+
 class tzwhere(object):
 
     SHORTCUT_DEGREES_LATITUDE = 1
@@ -249,13 +250,14 @@ Usage:
 
 Modes:
 
-  test - try out a few test locations.  <input_path> is the path to
-         read in, and defaults to an appropriate value depending on
-         the --kind option as follows:
+  test - run unit tests on some test locations, where we simply test that
+         the computed timezone for a given location is the one we expect.
+         <input_path> is the path to read in, and defaults to an
+         appropriate value depending on the --kind option as follows:
 
-         json...: {default_json}
-         pickle.: {default_pickle}
-         csv....: {default_csv}
+             json...: {default_json}
+             pickle.: {default_pickle}
+             csv....: {default_csv}
 
   write_pickle - write out a pickle file of a feature collection;
                  <input_path> is as with test.  <output_path> is also
@@ -269,8 +271,8 @@ Modes:
               N.b.: don't do this with -k csv
 
 Options:
-  -k <kind>, --kind=<kind>  Input kind.
-                            Should be json or pickle [default: json].
+  -k <kind>, --kind=<kind>  Input kind. Should be json or csv or pickle
+                            [default: json].
   -m, --memory              Report on memory usage before, during, and
                             after operation.
   -h, --help                Show this help.
@@ -280,6 +282,9 @@ Options:
     'default_pickle': tzwhere.DEFAULT_PICKLE,
     'default_csv': tzwhere.DEFAULT_CSV,
 })
+
+
+report_memory = False
 
 
 def main():
@@ -298,11 +303,17 @@ def main():
     if args['test']:
         test(args['--kind'], args['<input_path>'])
     elif args['write_pickle']:
+        if args['--kind'] not in ('json', 'pickle'):
+            print "Can't write pickle output from CSV input"
+            return
         if args['<output_path>'] is None:
             args['<output_path>'] = tzwhere.DEFAULT_PICKLE
         write_pickle(args['--kind'], args['<input_path>'],
                      args['<output_path>'])
     elif args['write_csv']:
+        if args['--kind'] not in ('json', 'pickle'):
+            print "Can't write CSV output from CSV input"
+            return
         if args['<output_path>'] is None:
             args['<output_path>'] = tzwhere.DEFAULT_CSV
         write_csv(args['--kind'], args['<input_path>'],
@@ -317,17 +328,47 @@ def test(input_kind, path):
     print 'Initialized in: ',
     print end - start
     memuse()
-    for (lat, lon, loc, expected) in (
-        (35.295953, -89.662186, 'Arlington, TN', 'America/Chicago'),
-        (33.58,     -85.85,     'Memphis, TN',   'America/Chicago'),
-        (61.17,     -150.02,    'Anchorage, AK', 'America/Anchorage'),
-        (44.12,     -123.22,    'Eugene, OR',    'America/Los_Angeles'),
-        (42.652647, -73.756371, 'Albany, NY',    'America/New_York'),
-    ):
-        actual = w.tzNameAt(float(lat), float(lon))
-        ok = 'OK' if actual == expected else 'XX'
-        print('{0} | {1:20s} | {2:20s} | {3:20s}'.format(
-            ok, loc, actual, expected))
+    template = '{0:20s} | {1:20s} | {2:20s} | {3:2s}'
+    print(template.format('LOCATION', 'EXPECTED', 'COMPUTED', '=='))
+    TEST_LOCATIONS = (
+        ( 35.295953,  -89.662186,  'Arlington, TN',        'America/Chicago'),
+        ( 33.58,      -85.85,      'Memphis, TN',          'America/Chicago'),
+        ( 61.17,     -150.02,      'Anchorage, AK',        'America/Anchorage'),
+        ( 44.12,     -123.22,      'Eugene, OR',           'America/Los_Angeles'),
+        ( 42.652647,  -73.756371,  'Albany, NY',           'America/New_York'),
+        ( 55.743749,   37.6207923, 'Moscow',               'Europe/Moscow'),
+        ( 34.104255, -118.4055591, 'Los Angeles',          'America/Los_Angeles'),
+        ( 55.743749,   37.6207923, 'Moscow',               'Europe/Moscow'),
+        ( 39.194991, -106.8294024, 'Aspen, Colorado',      'America/Denver'),
+        ( 50.438114,   30.5179595, 'Kiev',                 'Europe/Kiev'),
+        ( 12.936873,   77.6909136, 'Jogupalya',            'Asia/Kolkata'),
+        ( 38.889144,  -77.0398235, 'Washington DC',        'America/New_York'),
+        ( 59.932490,   30.3164291, 'St Petersburg',        'Europe/Moscow'),
+        ( 50.300624,  127.559166,  'Blagoveshchensk',      'Asia/Yakutsk'),
+        ( 42.439370,  -71.0700416, 'Boston',               'America/New_York'),
+        ( 41.84937,   -87.6611995, 'Chicago',              'America/Chicago'),
+        ( 28.626873,  -81.7584514, 'Orlando',              'America/New_York'),
+        ( 47.610615, -122.3324847, 'Seattle',              'America/Los_Angeles'),
+        ( 51.499990,   -0.1353549, 'London',               'Europe/London'),
+        ( 51.256241,   -0.8186531, 'Church Crookham',      'Europe/London'),
+        ( 51.292215,   -0.8002638, 'Fleet',                'Europe/London'),
+        ( 48.868743,    2.3237586, 'Paris',                'Europe/Paris'),
+        ( 22.158114,  113.5504603, 'Macau',                'Asia/Macau'),
+        ( 56.833123,   60.6097054, 'Russia',               'Asia/Yekaterinburg'),
+        ( 60.887496,   26.6375756, 'Salo',                 'Europe/Helsinki'),
+        ( 52.799992,   -1.8524408, 'Staffordshire',        'Europe/London'),
+        (  5.016666,  115.0666667, 'Muara',                'Asia/Brunei'),
+        (-41.466666,  -72.95,      'Puerto Montt seaport', 'America/Santiago'),
+        ( 34.566666,   33.0333333, 'Akrotiri seaport',     'Asia/Nicosia'),
+        ( 37.466666,  126.6166667, 'Inchon seaport',       'Asia/Seoul'),
+        ( 42.8,       132.8833333, 'Nakhodka seaport',     'Asia/Vladivostok'),
+        ( 50.26,       -5.051,     'Truro',                'Europe/London'),
+        ( 50.26,       -8.051,     'Sea off Cornwall',     None)
+    )
+    for (lat, lon, loc, expected) in TEST_LOCATIONS:
+        computed = w.tzNameAt(float(lat), float(lon))
+        ok = 'OK' if computed == expected else 'XX'
+        print(template.format(loc, expected, computed, ok))
     memuse()
 
 


### PR DESCRIPTION
Hi there. You might hate this, but in case you don't, please feel free to pull it and make a new release if you want. I've changed a *lot* though.

The main thing is that I noticed that reading in the JSON (before doing any processing) consumed 750MB of RAM - and actually this never got released properly ([apparently this is known behaviour with JSON and python](http://stackoverflow.com/a/11058050/392743)).  So I played around and found that by using a CSV file, each line of which is a single (tzname, polygon) pair, I can read that in one line at a time and save hundreds of MB.

Then I found out that by representing points as (lat, lng) pairs rather than two-element dictionaries, we save a couple of hundred MB again.

Then I found out that by using `numpy` arrays (if `numpy` is installed) instead of tuples for the polygons and lists of polygon lists, we can save even more.  (If `numpy` isn't installed, it falls back to tuples.)

Overall, I've got the memory usage down from 750MB to 60MB in the best case.

Along the way I've considerably refactored the `tzwhere.py` script, including adding the capability to produce this CSV file, and also (this might be the bit you like least) moving from `argparse` to `docopt`, just because I find it more flexible.  That means the script's options have changed, and I have also changed the public interface of the `tzwhere` class, so this is quite a big change really, and potentially breaking for client code.

Well, see what you think.  I'm happy to keep it as a separate fork if you want, but if you like it, great.

(This is all with python2.7 however - not tested with anything else.)