### PR TITLE
Fix type in 'shp' extension

### DIFF
--- a/getOriginalData.sh
+++ b/getOriginalData.sh
@@ -3,7 +3,7 @@
 # This is a basic script that downloads the original data and converts it to a JSON
 wget http://efele.net/maps/tz/world/tz_world.zip
 unzip tz_world
-ogr2ogr -f GeoJSON -t_srs crs:84 tz_world.json ./world/tz_world.sph
+ogr2ogr -f GeoJSON -t_srs crs:84 tz_world.json ./world/tz_world.shp
 mv tz_world.json tzwhere/
 rm ./world/ -r
 rm tz_world.zip


### PR DESCRIPTION
Looks like that was accidentally broke in https://github.com/pegler/pytzwhere/commit/9507ef1386f6d2c211b4887eb567cf0ea720c750