### PR TITLE
let users of the module to determine their logging configuration

### DIFF
--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -36,8 +36,6 @@ try:
 except ImportError:
     WRAP = tuple
 
-LOGGER_FORMAT = '%(asctime)-15s %(filename)s %(funcName)s %(lineno)d %(levelname)s  %(message)s'
-logging.basicConfig(format=LOGGER_FORMAT, level=logging.DEBUG)
 LOGGER = logging.getLogger('pytzwhere')
 
 
@@ -357,6 +355,10 @@ report_memory = False
 
 
 def main():
+
+    LOGGER_FORMAT = '%(asctime)-15s %(filename)s %(funcName)s %(lineno)d %(levelname)s  %(message)s'
+    logging.basicConfig(format=LOGGER_FORMAT, level=logging.DEBUG)
+
     try:
         import docopt
     except ImportError:

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -259,7 +259,7 @@ class tzwhere(object):
     def read_json(path=None):
         if path is None:
             path = tzwhere.DEFAULT_JSON
-        logging.info('Reading json input file: %s\n' % path)
+        LOGGER.info('Reading json input file: %s\n' % path)
         with open(path, 'r') as f:
             featureCollection = json.load(f)
         return featureCollection
@@ -268,14 +268,14 @@ class tzwhere(object):
     def read_pickle(path=None):
         if path is None:
             path = tzwhere.DEFAULT_PICKLE
-        logging.info('Reading pickle input file: %s\n' % path)
+        LOGGER.info('Reading pickle input file: %s\n' % path)
         with open(path, 'rb') as f:
             featureCollection = pickle.load(f)
         return featureCollection
 
     @staticmethod
     def write_pickle(featureCollection, path=DEFAULT_PICKLE):
-        logging.info('Writing pickle output file: %s\n' % path)
+        LOGGER.info('Writing pickle output file: %s\n' % path)
         with open(path, 'wb') as f:
             pickle.dump(featureCollection, f, protocol=2)
 
@@ -283,7 +283,7 @@ class tzwhere(object):
     def _read_polygons_from_csv(path=None):
         if path is None:
             path = tzwhere.DEFAULT_CSV
-        logging.info('Reading from CSV input file: %s\n' % path)
+        LOGGER.info('Reading from CSV input file: %s\n' % path)
         with open(path, 'r') as f:
             for row in f:
                 row = row.split(',')
@@ -291,7 +291,7 @@ class tzwhere(object):
 
     @staticmethod
     def write_csv(featureCollection, path=DEFAULT_CSV):
-        logging.info('Writing csv output file: %s\n' % path)
+        LOGGER.info('Writing csv output file: %s\n' % path)
         with open(path, 'w') as f:
             writer = csv.writer(f)
             for (tzname, polygon) in tzwhere._feature_collection_polygons(
@@ -366,7 +366,7 @@ def main():
         import sys
         sys.exit(1)
 
-    logging.info('Application started..')
+    LOGGER.info('Application started..')
     args = docopt.docopt(HELP)
 
     global report_memory


### PR DESCRIPTION
By moving the configuration of logging out of the top-level and into main, users using tzwhere interactively still get logging while consumers using the library as a library don't have their logging config impacted.

The use of logging.basicConfig at the top level has been causing some of our applications to print all of their logs to stdout for a few days now.