### PR TITLE
Use the right sort key inside `forceTz`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*
+    *__init__*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -10,7 +9,7 @@ install:
   - pip install -e .
   - pip install -r tests/requirements.txt
 # command to run tests
-script: 
+script:
   - nosetests --with-coverage --cover-branches --cover-inclusive --cover-package=tzwhere
 after_script:
   coveralls

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -47,6 +47,7 @@ class LocationTestCase(unittest.TestCase):
             ( 61.17,     -150.02,      'Anchorage, AK',        'America/Anchorage'),
             ( 40.7271,   -73.98,       'Shore Lake Michigan',  'America/New_York'),
             ( 50.1536,   -8.051,       'Off Cornwall',         'Europe/London'),
+            ( 49.2698,   -123.1302,    'Vancouver',            'America/Vancouver'),
             ( 50.26,       -9.051,     'Far off Cornwall',     None)
     )
 

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -230,7 +230,7 @@ class tzwhere(object):
                             distances.append((d, tzname))
             if len(distances) > 0:
                 # Sort by distances, and then return the timezone name of the first instance in the sorted list
-                return sorted(distances, key=lambda x: x[1])[0][1]
+                return sorted(distances, key=lambda x: x[0])[0][1]
 
     @staticmethod
     def _point_inside_polygon(x, y, poly):

--- a/tzwhere/tzwhere.py
+++ b/tzwhere/tzwhere.py
@@ -229,6 +229,7 @@ class tzwhere(object):
                             d = poly.distance(queryPoint)
                             distances.append((d, tzname))
             if len(distances) > 0:
+                # Sort by distances, and then return the timezone name of the first instance in the sorted list
                 return sorted(distances, key=lambda x: x[1])[0][1]
 
     @staticmethod


### PR DESCRIPTION
Currently the possible timezones are sorted by the timezone name itself, not the distance

This PR points it to the right key