### PR TITLE
Make numpy optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ The polygons used for building the timezones are based on VMAP0. Sometimes point
 
 Dependencies:
 
-  * `numpy`
+  * `numpy` (optional)
 
   * `shapely`

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         },
     include_package_data=True,
     install_requires=[
-        'numpy',
         'shapely'
     ],
     license='MIT License',

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,11 @@ setup(
     version='3.0',
     packages=['tzwhere'],
     package_data={
-        'tzwhere': ['tz_world.json']
-        },
+        'tzwhere': [
+            'tz_world.json',
+            'tz_world_shortcuts.json'
+        ]
+    },
     include_package_data=True,
     install_requires=[
         'shapely'


### PR DESCRIPTION
Hi @pegler,

In your last merge, `docopt`, `shapely` and `numpy` are all made into required dependencies rather than optional. While we are okay with `docopt` and `shapely`, `numpy` is a rather heavy dependency and it does not play nicely with our existing codebase in production.

Is there any chance it can be made optional again? (I've done this on our fork anyway as you can see in this PR)