### PR TITLE
add json files to MANIFEST.in, remove obsolete .csv file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
-include tzwhere/tz_world.csv
+include tzwhere/tz_world.json
+include tzwhere/tz_world_shortcuts.json


### PR DESCRIPTION
According to https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=include_package_data#including-data-files all files that should be installed automatically when using `include_package_data=True` in setup.py must be included in the MANIFEST.in
Also `tzwhere/tz_world.csv` has been removed in https://github.com/pegler/pytzwhere/commit/df871d2dfaed96a8d537b0f57f2a6d00fd2bb024

This pull request should fix the installation of the missing json files reported in #44 and #45 